### PR TITLE
Marca d'água para documentos cancelados

### DIFF
--- a/DanfeSharp/Danfe.cs
+++ b/DanfeSharp/Danfe.cs
@@ -181,6 +181,10 @@ namespace DanfeSharp
                 p.DesenharAvisoHomologacao();
             }
 
+            // NF-e cancelada
+            if (ViewModel.CodigoStatusReposta == 101)
+                p.DesenharAvisoCancelamento();
+
             return p;
         }
 

--- a/DanfeSharp/DanfePagina.cs
+++ b/DanfeSharp/DanfePagina.cs
@@ -91,6 +91,22 @@ namespace DanfeSharp
             Gfx.Flush();
         }
 
+        public void DesenharAvisoCancelamento()
+        {
+            TextStack ts = new TextStack(RetanguloCorpo)
+            {
+                AlinhamentoVertical = AlinhamentoVertical.Centro,
+                AlinhamentoHorizontal = AlinhamentoHorizontal.Centro,
+                LineHeightScale = 0.9F
+            }
+            .AddLine("DOCUMENTO CANCELADO", Danfe.EstiloPadrao.CriarFonteRegular(48));
+ 
+            Gfx.PrimitiveComposer.BeginLocalState();
+            Gfx.PrimitiveComposer.SetFillColor(new org.pdfclown.documents.contents.colorSpaces.DeviceRGBColor(0.35, 0.35, 0.35));
+            ts.Draw(Gfx);
+            Gfx.PrimitiveComposer.End();
+        }
+
         public void DesenharAvisoHomologacao()
         {
             TextStack ts = new TextStack(RetanguloCorpo) { AlinhamentoVertical = AlinhamentoVertical.Centro, AlinhamentoHorizontal = AlinhamentoHorizontal.Centro, LineHeightScale = 0.9F }


### PR DESCRIPTION
Desenhar marca d'água "Documento Cancelado" quando CodigoStatusResposta for igual a 101.