### PR TITLE
feat(nfce): Use two lines for items text

### DIFF
--- a/DanfeSharp/Blocos/NFC/TabelaProdutosServicosNFC.cs
+++ b/DanfeSharp/Blocos/NFC/TabelaProdutosServicosNFC.cs
@@ -8,10 +8,12 @@ namespace DanfeSharp.Blocos.NFC
     {
         public TabelaProdutosServicosNFC(DanfeViewModel viewModel, Estilo estilo, PrimitiveComposer primitiveComposer, float y) : base(estilo)
         {
-            if (y == 40)
-                Y_NFC = 100;
-            if (y == 50)
-                Y_NFC = 100 + 10;
+            Y_NFC = y switch
+            {
+                40 => 100,
+                50 => 100 + 10,
+                _ => Y_NFC
+            };
 
             primitiveComposer.BeginLocalState();
             primitiveComposer.SetFont(estilo.FonteCampoTituloNegrito.FonteInterna, estilo.FonteCampoTituloNegrito.Tamanho);
@@ -28,31 +30,40 @@ namespace DanfeSharp.Blocos.NFC
             primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));
 
             primitiveComposer.SetFont(estilo.FonteCampoConteudo.FonteInterna, estilo.FonteCampoConteudo.Tamanho);
-            primitiveComposer.ShowText("CÓDIGO", new PointF(40, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-            primitiveComposer.ShowText("DESC.", new PointF(90, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-            primitiveComposer.ShowText("QTD.", new PointF(140, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-            primitiveComposer.ShowText("UNID.", new PointF(170, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-            primitiveComposer.ShowText("PREÇO", new PointF(200, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-            primitiveComposer.ShowText("TOTAL", new PointF(240, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("CÓDIGO", new PointF(60, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("DESCRIÇÃO", new PointF(70, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
+
+            Y_NFC += 10;
+
+            primitiveComposer.ShowText("QTD.", new PointF(70, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("UNID.", new PointF(100, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("PREÇO", new PointF(200, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("TOTAL", new PointF(250, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+
+            Y_NFC += 10;
+
+            primitiveComposer.DrawLine(new PointF(15, Y_NFC), new PointF(265, Y_NFC));
+            primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));
 
             foreach (var produto in viewModel.Produtos)
             {
-                Y_NFC = Y_NFC + 10;
+                Y_NFC += 10;
+
                 primitiveComposer.SetFont(estilo.FonteCampoConteudo.FonteInterna, estilo.FonteCampoConteudo.Tamanho);
-                primitiveComposer.ShowText(produto.Codigo, new PointF(40, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.Codigo.Length > 15 ? produto.Codigo.Substring(0, 10) : produto.Codigo,
+                    new PointF(60, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.Descricao.Length > 40 ? produto.Descricao.Substring(0, 40) : produto.Descricao,
+                    new PointF(70, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
 
-                if (produto.Descricao.Length >= 10)
-                    primitiveComposer.ShowText(produto.Descricao.Substring(0, 10), new PointF(90, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-                else
-                    primitiveComposer.ShowText(produto.Descricao, new PointF(90, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                Y_NFC += 10;
 
-                primitiveComposer.ShowText(produto.Quantidade.Formatar(), new PointF(140, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-                primitiveComposer.ShowText(produto.Unidade, new PointF(170, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-                primitiveComposer.ShowText(produto.ValorUnitario.Formatar(), new PointF(200, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
-                primitiveComposer.ShowText(produto.ValorTotal.Formatar(), new PointF(240, Y_NFC), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.Quantidade.Formatar(), new PointF(90, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.Unidade, new PointF(100, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.ValorUnitario.Formatar(), new PointF(200, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText(produto.ValorTotal.Formatar(), new PointF(250, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
             }
 
-            Y_NFC = Y_NFC + 10;
+            Y_NFC += 10;
 
             primitiveComposer.DrawLine(new PointF(15, Y_NFC), new PointF(265, Y_NFC));
             primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));

--- a/DanfeSharp/Blocos/NFC/TabelaProdutosServicosNFC.cs
+++ b/DanfeSharp/Blocos/NFC/TabelaProdutosServicosNFC.cs
@@ -30,7 +30,7 @@ namespace DanfeSharp.Blocos.NFC
             primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));
 
             primitiveComposer.SetFont(estilo.FonteCampoConteudo.FonteInterna, estilo.FonteCampoConteudo.Tamanho);
-            primitiveComposer.ShowText("CÓDIGO", new PointF(60, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+            primitiveComposer.ShowText("CÓDIGO", new PointF(65, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
             primitiveComposer.ShowText("DESCRIÇÃO", new PointF(70, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
 
             Y_NFC += 10;
@@ -51,7 +51,7 @@ namespace DanfeSharp.Blocos.NFC
 
                 primitiveComposer.SetFont(estilo.FonteCampoConteudo.FonteInterna, estilo.FonteCampoConteudo.Tamanho);
                 primitiveComposer.ShowText(produto.Codigo.Length > 15 ? produto.Codigo.Substring(0, 10) : produto.Codigo,
-                    new PointF(60, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
+                    new PointF(65, Y_NFC), XAlignmentEnum.Right, YAlignmentEnum.Middle, 0);
                 primitiveComposer.ShowText(produto.Descricao.Length > 40 ? produto.Descricao.Substring(0, 40) : produto.Descricao,
                     new PointF(70, Y_NFC), XAlignmentEnum.Left, YAlignmentEnum.Middle, 0);
 


### PR DESCRIPTION
Raise item code max length to 15 characters and description to 40 characters (truncated)

_Before_
![image](https://github.com/user-attachments/assets/7f6f7070-4386-435c-9562-e928c7685815)

_After_
![image](https://github.com/user-attachments/assets/6b06ec54-439a-4bae-8dee-5f12145b7590)

