### PR TITLE
feat: render Nota de Crédito por Recusa header (Ajustes SINIEF 49/25 + 8/26)

### DIFF
--- a/DanfeSharp/Elementos/NumeroNfSerie2.cs
+++ b/DanfeSharp/Elementos/NumeroNfSerie2.cs
@@ -61,7 +61,10 @@ namespace DanfeSharp
             .AddLine("Nota Fiscal Eletrônica", f2);
 
             // Para Nota de Crédito por Recusa, exibe o subtipo (Total / Parcial)
-            // logo abaixo do bloco descritivo.
+            // logo abaixo do bloco descritivo. Quando presente, o TextStack
+            // ganha uma 3ª linha — o cálculo do CutTop precisa refletir isso
+            // para não sobrepor o bloco "ENTRADA/SAÍDA" abaixo.
+            float subtipoLineHeight = 0F;
             if (isNotaCredito && ViewModel.TipoNotaCredito.HasValue)
             {
                 string subtipo = ViewModel.TipoNotaCredito.Value switch
@@ -70,12 +73,14 @@ namespace DanfeSharp
                     6 => "(Recusa Parcial)",
                     _ => $"(tpNFCredito={ViewModel.TipoNotaCredito.Value:D2})"
                 };
-                ts.AddLine(subtipo, Estilo.CriarFonteNegrito(7F));
+                var fSubtipo = Estilo.CriarFonteNegrito(7F);
+                ts.AddLine(subtipo, fSubtipo);
+                subtipoLineHeight = (float)fSubtipo.AlturaLinha * TextStack.DefaultLineHeightScale;
             }
 
             ts.Draw(gfx);
 
-            rp2 = rp2.CutTop(2F * f2h + 1.5F);
+            rp2 = rp2.CutTop(2F * f2h + subtipoLineHeight + 1.5F);
 
 
             ts = new TextStack(rp2)

--- a/DanfeSharp/Elementos/NumeroNfSerie2.cs
+++ b/DanfeSharp/Elementos/NumeroNfSerie2.cs
@@ -39,9 +39,14 @@ namespace DanfeSharp
             var rp1 = BoundingBox.InflatedRetangle(1F, 0.5F, paddingHorizontal);
             var rp2 = rp1;
 
-            var f1 = Estilo.CriarFonteNegrito(12);
+            // Cabeçalho: "DANFE" para NF-e regular, "NOTA DE CRÉDITO" quando
+            // finNFe=5 (Ajustes SINIEF 49/25 + 8/26). Tamanho de fonte ajustado
+            // para acomodar o título mais longo no mesmo retângulo.
+            bool isNotaCredito = ViewModel.Finalidade == 5;
+            string tituloCabecalho = isNotaCredito ? "NOTA DE CRÉDITO" : "DANFE";
+            var f1 = Estilo.CriarFonteNegrito(isNotaCredito ? 10 : 12);
             var f1h = f1.AlturaLinha;
-            gfx.DrawString("DANFE", rp2, f1, AlinhamentoHorizontal.Centro);
+            gfx.DrawString(tituloCabecalho, rp2, f1, AlinhamentoHorizontal.Centro);
 
             rp2 = rp2.CutTop(f1h + 0.5F);
 
@@ -54,6 +59,19 @@ namespace DanfeSharp
             }
             .AddLine("Documento Auxiliar da", f2)
             .AddLine("Nota Fiscal Eletrônica", f2);
+
+            // Para Nota de Crédito por Recusa, exibe o subtipo (Total / Parcial)
+            // logo abaixo do bloco descritivo.
+            if (isNotaCredito && ViewModel.TipoNotaCredito.HasValue)
+            {
+                string subtipo = ViewModel.TipoNotaCredito.Value switch
+                {
+                    3 => "(Recusa Total / Não Localização)",
+                    6 => "(Recusa Parcial)",
+                    _ => $"(tpNFCredito={ViewModel.TipoNotaCredito.Value:D2})"
+                };
+                ts.AddLine(subtipo, Estilo.CriarFonteNegrito(7F));
+            }
 
             ts.Draw(gfx);
 

--- a/DanfeSharp/Esquemas/ProcNFe.cs
+++ b/DanfeSharp/Esquemas/ProcNFe.cs
@@ -917,6 +917,22 @@ namespace DanfeSharp.Esquemas.NFe
         [XmlElementAttribute("NFref")]
         public List<NFReferenciada> NFref { get; set; }
 
+        /// <summary>
+        /// Finalidade de emissão da NF-e (1=Normal; 2=Complementar; 3=Ajuste;
+        /// 4=Devolução; 5=Nota de Crédito — Ajustes SINIEF 49/25 + 8/26).
+        /// Nullable pois XMLs antigos podem não conter o campo.
+        /// </summary>
+        public int? finNFe { get; set; }
+
+        /// <summary>
+        /// Tipo da Nota de Crédito (tpNFCredito), aplicável quando finNFe=5.
+        /// 01..05 conforme Ajuste 49/25, 06=Recusa Parcial conforme Ajuste 8/26.
+        /// </summary>
+        public string tpNFCredito { get; set; }
+
+        public bool ShouldSerializefinNFe() => finNFe.HasValue;
+        public bool ShouldSerializetpNFCredito() => !string.IsNullOrEmpty(tpNFCredito);
+
         public Identificacao()
         {
             NFref = new List<NFReferenciada>();

--- a/DanfeSharp/Esquemas/ProcNFe.cs
+++ b/DanfeSharp/Esquemas/ProcNFe.cs
@@ -341,8 +341,41 @@ namespace DanfeSharp.Esquemas.NFe
         public ProdutoImposto imposto { get; set; }
         public string infAdProd { get; set; }
 
+        /// <summary>
+        /// Grupo de Documento Fiscal Eletrônico Referenciado (det/DFeReferenciado).
+        /// Usado em Nota de Crédito por Recusa Parcial (tpNFCredito=06, Ajuste
+        /// SINIEF 8/26) para indicar a NF-e original e o item específico a que
+        /// o item da Nota de Crédito faz referência.
+        /// </summary>
+        public DFeReferenciado DFeReferenciado { get; set; }
+
+        public bool ShouldSerializeDFeReferenciado() => DFeReferenciado != null;
+
         [XmlAttribute]
         public string nItem { get; set; }
+    }
+
+    /// <summary>
+    /// Grupo de Documento Fiscal Eletrônico Referenciado por item.
+    /// Conforme Ajuste SINIEF 8/26 (Nota de Crédito por Recusa Parcial,
+    /// tpNFCredito=06), cada item da NF-e de crédito pode referenciar o item
+    /// específico da NF-e original que está sendo recusado parcialmente.
+    /// </summary>
+    [Serializable]
+    [XmlType(AnonymousType = true, Namespace = Namespaces.NFe)]
+    public class DFeReferenciado
+    {
+        /// <summary>
+        /// Chave de Acesso da NF-e original referenciada (44 dígitos).
+        /// </summary>
+        public string chaveAcesso { get; set; }
+
+        /// <summary>
+        /// Número do item específico na NF-e original referenciada.
+        /// </summary>
+        public int? nItem { get; set; }
+
+        public bool ShouldSerializenItem() => nItem.HasValue;
     }
 
     /// <summary>

--- a/DanfeSharp/Modelo/DanfeViewModel.cs
+++ b/DanfeSharp/Modelo/DanfeViewModel.cs
@@ -147,6 +147,25 @@ namespace DanfeSharp.Modelo
         public int TipoNF { get; set; }
 
         /// <summary>
+        /// Finalidade de emissão da NF-e (tag finNFe).
+        /// 1=Normal; 2=Complementar; 3=Ajuste; 4=Devolução;
+        /// 5=Nota de Crédito (Ajustes SINIEF 49/25 + 8/26).
+        /// Quando 5, o cabeçalho do DANFE é renderizado como
+        /// "NOTA DE CRÉDITO" no lugar de "DANFE".
+        /// </summary>
+        public int? Finalidade { get; set; }
+
+        /// <summary>
+        /// Tipo da Nota de Crédito (tag tpNFCredito), aplicável quando
+        /// <see cref="Finalidade"/> = 5.
+        /// 01=Multa e juros; 02=Apropriação de crédito presumido (ZFM);
+        /// 03=Recusa total ou não localização do destinatário;
+        /// 04=Redução de valores; 05=Transferência de crédito na sucessão;
+        /// 06=Recusa parcial na entrega (Ajuste SINIEF 8/26).
+        /// </summary>
+        public int? TipoNotaCredito { get; set; }
+
+        /// <summary>
         /// Numero do protocolo com sua data e hora
         /// </summary>
         public String ProtocoloAutorizacao { get; set; }

--- a/DanfeSharp/Modelo/DanfeViewModelCreator.cs
+++ b/DanfeSharp/Modelo/DanfeViewModelCreator.cs
@@ -466,6 +466,16 @@ namespace DanfeSharp.Modelo
                 produto.ValorTotal = det.prod.vProd;
                 produto.InformacoesAdicionais = det?.infAdProd?.Replace("\\n", "\n");
 
+                // Para Nota de Crédito por Recusa Parcial (Ajuste SINIEF 8/26),
+                // cada item pode referenciar um item específico da NF-e original
+                // via det/DFeReferenciado. Quando presente, esses dados são
+                // anexados à DescricaoCompleta para aparecer no DANFE.
+                if (det?.DFeReferenciado != null)
+                {
+                    produto.ChaveAcessoReferenciada = det.DFeReferenciado.chaveAcesso;
+                    produto.NumeroItemReferenciado = det.DFeReferenciado.nItem;
+                }
+
                 var imposto = det.imposto;
 
                 if (imposto != null)

--- a/DanfeSharp/Modelo/DanfeViewModelCreator.cs
+++ b/DanfeSharp/Modelo/DanfeViewModelCreator.cs
@@ -418,6 +418,12 @@ namespace DanfeSharp.Modelo
             model.NaturezaOperacao = ide.natOp;
             model.ChaveAcesso = procNfe.NFe.infNFe.Id.Substring(3);
             model.TipoNF = (int)ide.tpNF;
+            model.Finalidade = ide.finNFe;
+
+            if (!string.IsNullOrEmpty(ide.tpNFCredito) && int.TryParse(ide.tpNFCredito, out var tpCredito))
+            {
+                model.TipoNotaCredito = tpCredito;
+            }
 
             model.TipoEmissao = ide.tpEmis;
             model.ContingenciaDataHora = ide.dhCont;

--- a/DanfeSharp/Modelo/ProdutoViewModel.cs
+++ b/DanfeSharp/Modelo/ProdutoViewModel.cs
@@ -105,6 +105,21 @@ namespace DanfeSharp.Modelo
         /// </summary>
         public double? ValorAproximadoTributos { get; set; }
 
+        /// <summary>
+        /// <para>Chave de acesso (44 dígitos) da NF-e original referenciada por este item.</para>
+        /// <para>Aplicável apenas em Notas de Crédito por Recusa Parcial
+        /// (<c>finNFe=5</c> + <c>tpNFCredito=06</c>, Ajuste SINIEF 8/26).
+        /// Mapeia para <c>det/DFeReferenciado/chaveAcesso</c>.</para>
+        /// </summary>
+        public String ChaveAcessoReferenciada { get; set; }
+
+        /// <summary>
+        /// <para>Número do item específico no documento referenciado.</para>
+        /// <para>Aplicável apenas em Notas de Crédito por Recusa Parcial.
+        /// Mapeia para <c>det/DFeReferenciado/nItem</c>.</para>
+        /// </summary>
+        public int? NumeroItemReferenciado { get; set; }
+
         public ProdutoViewModel()
         {
             AliquotaIpi = null;
@@ -120,6 +135,18 @@ namespace DanfeSharp.Modelo
                 if (!String.IsNullOrWhiteSpace(InformacoesAdicionais))
                 {
                     descriCaoCompleta += "\r\n" + InformacoesAdicionais;
+                }
+
+                // Para Nota de Crédito por Recusa Parcial: anexa a referência
+                // ao item recusado da NF-e original na descrição (sem coluna
+                // dedicada, mantendo o layout do DANFE clássico).
+                if (!String.IsNullOrWhiteSpace(ChaveAcessoReferenciada))
+                {
+                    descriCaoCompleta += "\r\nNF-e ref.: " + ChaveAcessoReferenciada;
+                    if (NumeroItemReferenciado.HasValue)
+                    {
+                        descriCaoCompleta += " — item " + NumeroItemReferenciado.Value;
+                    }
                 }
 
                 return descriCaoCompleta;


### PR DESCRIPTION
## Summary

Adiciona suporte à renderização de DANFE para **Nota de Crédito por Recusa** (`finNFe=5` + `tpNFCredito` 03 ou 06) instituída pelos Ajustes SINIEF **49/25** (12/2025) e **8/26** (vigência 04/05/2026).

## Mudanças

| Camada | Mudança |
|---|---|
| `Esquemas/ProcNFe.cs` | `Identificacao.finNFe : int?` e `Identificacao.tpNFCredito : string` com `ShouldSerialize` (preserva compat com XMLs sem o campo). |
| `Modelo/DanfeViewModel.cs` | Novos campos `Finalidade : int?` e `TipoNotaCredito : int?` expostos ao renderizador. |
| `Modelo/DanfeViewModelCreator.cs` | `CreateFromProcNFe` popula os novos campos quando presentes no XML. |
| `Elementos/NumeroNfSerie2.cs` | Cabeçalho renderizado como **"NOTA DE CRÉDITO"** (em vez de "DANFE") quando `Finalidade=5`. Tamanho da fonte ajustado de 12 → 10 para acomodar o título mais longo. Subtipo exibido logo abaixo: "(Recusa Total / Não Localização)" para `tpNFCredito=03`, "(Recusa Parcial)" para `06`, genérico para 01/02/04/05. |
| `Modelo/ProdutoViewModel.cs` | `ChaveAcessoReferenciada` e `NumeroItemReferenciado` opcionais. Quando preenchidos, anexados a `DescricaoCompleta` no formato `"NF-e ref.: <chave> — item N"`, cobrindo `det/DFeReferenciado` exigido em Recusa Parcial sem introduzir coluna nova no layout clássico. |

## Compatibilidade

Para XMLs / Invoices sem `finNFe` ou `tpNFCredito` (qualquer NF-e existente hoje), o comportamento atual é preservado integralmente — todos os novos campos são nullable / opcionais, e o cabeçalho continua sendo "DANFE" por default.

## Test plan

- [x] `dotnet build DanfeSharp/DanfeSharp.csproj` — 0 erros.
- [ ] Validar visual: gerar PDF de uma NF-e regular (deve continuar como "DANFE", sem mudança).
- [ ] Validar visual: gerar PDF de uma Nota de Crédito Recusa Total — cabeçalho "NOTA DE CRÉDITO" + subtipo "(Recusa Total / Não Localização)".
- [ ] Validar visual: gerar PDF de uma Nota de Crédito Recusa Parcial — cabeçalho + subtipo "(Recusa Parcial)" + cada item com referência "NF-e ref.: ... — item N".

## Contexto

Desbloqueia D2 (DANFE) da implementação da emissão de Nota de Crédito por Recusa em [`nfe/dfetech-product-invoice-api#66`](https://github.com/nfe/dfetech-product-invoice-api/pull/66) — issue umbrella [`#45`](https://github.com/nfe/dfetech-product-invoice-api/issues/45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)