### PR TITLE
feat: render Nota de Débito header (Ajuste SINIEF 49/25)

### DIFF
--- a/DanfeSharp/Elementos/NumeroNfSerie2.cs
+++ b/DanfeSharp/Elementos/NumeroNfSerie2.cs
@@ -40,11 +40,16 @@ namespace DanfeSharp
             var rp2 = rp1;
 
             // Cabeçalho: "DANFE" para NF-e regular, "NOTA DE CRÉDITO" quando
-            // finNFe=5 (Ajustes SINIEF 49/25 + 8/26). Tamanho de fonte ajustado
-            // para acomodar o título mais longo no mesmo retângulo.
+            // finNFe=5 (Ajustes SINIEF 49/25 + 8/26), "NOTA DE DÉBITO" quando
+            // finNFe=6 (Ajuste SINIEF 49/25). Tamanho de fonte ajustado para
+            // acomodar o título mais longo no mesmo retângulo.
             bool isNotaCredito = ViewModel.Finalidade == 5;
-            string tituloCabecalho = isNotaCredito ? "NOTA DE CRÉDITO" : "DANFE";
-            var f1 = Estilo.CriarFonteNegrito(isNotaCredito ? 10 : 12);
+            bool isNotaDebito = ViewModel.Finalidade == 6;
+            string tituloCabecalho;
+            if (isNotaCredito) tituloCabecalho = "NOTA DE CRÉDITO";
+            else if (isNotaDebito) tituloCabecalho = "NOTA DE DÉBITO";
+            else tituloCabecalho = "DANFE";
+            var f1 = Estilo.CriarFonteNegrito(isNotaCredito || isNotaDebito ? 10 : 12);
             var f1h = f1.AlturaLinha;
             gfx.DrawString(tituloCabecalho, rp2, f1, AlinhamentoHorizontal.Centro);
 
@@ -60,7 +65,7 @@ namespace DanfeSharp
             .AddLine("Documento Auxiliar da", f2)
             .AddLine("Nota Fiscal Eletrônica", f2);
 
-            // Para Nota de Crédito por Recusa, exibe o subtipo (Total / Parcial)
+            // Para Nota de Crédito por Recusa / Nota de Débito, exibe o subtipo
             // logo abaixo do bloco descritivo. Quando presente, o TextStack
             // ganha uma 3ª linha — o cálculo do CutTop precisa refletir isso
             // para não sobrepor o bloco "ENTRADA/SAÍDA" abaixo.
@@ -72,6 +77,24 @@ namespace DanfeSharp
                     3 => "(Recusa Total / Não Localização)",
                     6 => "(Recusa Parcial)",
                     _ => $"(tpNFCredito={ViewModel.TipoNotaCredito.Value:D2})"
+                };
+                var fSubtipo = Estilo.CriarFonteNegrito(7F);
+                ts.AddLine(subtipo, fSubtipo);
+                subtipoLineHeight = (float)fSubtipo.AlturaLinha * TextStack.DefaultLineHeightScale;
+            }
+            else if (isNotaDebito && ViewModel.TipoNotaDebito.HasValue)
+            {
+                string subtipo = ViewModel.TipoNotaDebito.Value switch
+                {
+                    1 => "(Transferência de Créditos p/ Cooperativa)",
+                    2 => "(Cancelamento de Créditos)",
+                    3 => "(Débitos Não Processados)",
+                    4 => "(Multas / Juros)",
+                    5 => "(Sucessão)",
+                    6 => "(Pagamento Antecipado)",
+                    7 => "(Perda de Estoque)",
+                    8 => "(Desenquadramento Simples Nacional)",
+                    _ => $"(tpNFDebito={ViewModel.TipoNotaDebito.Value:D2})"
                 };
                 var fSubtipo = Estilo.CriarFonteNegrito(7F);
                 ts.AddLine(subtipo, fSubtipo);

--- a/DanfeSharp/Esquemas/ProcNFe.cs
+++ b/DanfeSharp/Esquemas/ProcNFe.cs
@@ -952,7 +952,8 @@ namespace DanfeSharp.Esquemas.NFe
 
         /// <summary>
         /// Finalidade de emissão da NF-e (1=Normal; 2=Complementar; 3=Ajuste;
-        /// 4=Devolução; 5=Nota de Crédito — Ajustes SINIEF 49/25 + 8/26).
+        /// 4=Devolução; 5=Nota de Crédito — Ajustes SINIEF 49/25 + 8/26;
+        /// 6=Nota de Débito — Ajuste SINIEF 49/25).
         /// Nullable pois XMLs antigos podem não conter o campo.
         /// </summary>
         public int? finNFe { get; set; }
@@ -963,8 +964,18 @@ namespace DanfeSharp.Esquemas.NFe
         /// </summary>
         public string tpNFCredito { get; set; }
 
+        /// <summary>
+        /// Tipo da Nota de Débito (tpNFDebito), aplicável quando finNFe=6.
+        /// 01..08 conforme Ajuste 49/25 (transferência de créditos para
+        /// cooperativas, cancelamento de créditos, débitos não processados,
+        /// multas/juros, sucessão, pagamento antecipado, perda de estoque,
+        /// desenquadramento Simples Nacional).
+        /// </summary>
+        public string tpNFDebito { get; set; }
+
         public bool ShouldSerializefinNFe() => finNFe.HasValue;
         public bool ShouldSerializetpNFCredito() => !string.IsNullOrEmpty(tpNFCredito);
+        public bool ShouldSerializetpNFDebito() => !string.IsNullOrEmpty(tpNFDebito);
 
         public Identificacao()
         {

--- a/DanfeSharp/Modelo/DanfeViewModel.cs
+++ b/DanfeSharp/Modelo/DanfeViewModel.cs
@@ -149,9 +149,12 @@ namespace DanfeSharp.Modelo
         /// <summary>
         /// Finalidade de emissão da NF-e (tag finNFe).
         /// 1=Normal; 2=Complementar; 3=Ajuste; 4=Devolução;
-        /// 5=Nota de Crédito (Ajustes SINIEF 49/25 + 8/26).
+        /// 5=Nota de Crédito (Ajustes SINIEF 49/25 + 8/26);
+        /// 6=Nota de Débito (Ajuste SINIEF 49/25).
         /// Quando 5, o cabeçalho do DANFE é renderizado como
         /// "NOTA DE CRÉDITO" no lugar de "DANFE".
+        /// Quando 6, o cabeçalho do DANFE é renderizado como
+        /// "NOTA DE DÉBITO" no lugar de "DANFE".
         /// </summary>
         public int? Finalidade { get; set; }
 
@@ -164,6 +167,17 @@ namespace DanfeSharp.Modelo
         /// 06=Recusa parcial na entrega (Ajuste SINIEF 8/26).
         /// </summary>
         public int? TipoNotaCredito { get; set; }
+
+        /// <summary>
+        /// Tipo da Nota de Débito (tag tpNFDebito), aplicável quando
+        /// <see cref="Finalidade"/> = 6.
+        /// 01=Transferência de créditos para cooperativas;
+        /// 02=Cancelamento de créditos; 03=Débitos não processados;
+        /// 04=Multas/juros; 05=Sucessão; 06=Pagamento antecipado;
+        /// 07=Perda de estoque; 08=Desenquadramento do Simples Nacional
+        /// (Ajuste SINIEF 49/25).
+        /// </summary>
+        public int? TipoNotaDebito { get; set; }
 
         /// <summary>
         /// Numero do protocolo com sua data e hora

--- a/DanfeSharp/Modelo/DanfeViewModelCreator.cs
+++ b/DanfeSharp/Modelo/DanfeViewModelCreator.cs
@@ -425,6 +425,11 @@ namespace DanfeSharp.Modelo
                 model.TipoNotaCredito = tpCredito;
             }
 
+            if (!string.IsNullOrEmpty(ide.tpNFDebito) && int.TryParse(ide.tpNFDebito, out var tpDebito))
+            {
+                model.TipoNotaDebito = tpDebito;
+            }
+
             model.TipoEmissao = ide.tpEmis;
             model.ContingenciaDataHora = ide.dhCont;
             model.ContingenciaJustificativa = ide.xJust;


### PR DESCRIPTION
## Sumário

Espelha o padrão consolidado pelo PR #31 (Nota de Crédito por Recusa) para suportar **Nota de Débito** — finalidade \`finNFe=6\` com discriminador \`tpNFDebito\` (01..08) conforme **Ajuste SINIEF 49/25**.

Necessário para o lado consumidor (\`dfetech-product-invoice-api\` PR [#70](https://github.com/nfe/dfetech-product-invoice-api/pull/70)) emitir o DANFE correto quando \`finNFe=6\`. Hoje o consumidor mantém um vendoring local da lib aguardando este merge.

## Mudanças

- **\`Identificacao.tpNFDebito\`** (\`string\`) em \`Esquemas/ProcNFe.cs\` + \`ShouldSerializetpNFDebito\`. Comentário de \`finNFe\` atualizado para incluir \`6=Nota de Débito\`.
- **\`DanfeViewModel.TipoNotaDebito\`** (\`int?\`) exposto ao renderizador, com docstring listando os 8 subtipos.
- **\`DanfeViewModelCreator.CreateFromProcNFe\`** popula a partir de \`ide.tpNFDebito\` (mesmo padrão do parsing de \`tpNFCredito\`).
- **\`NumeroNfSerie2.Draw\`**: cabeçalho \"NOTA DE DÉBITO\" (em vez de \"DANFE\") quando \`Finalidade=6\`. Fonte 10pt (igual à Nota de Crédito) para acomodar o título mais longo. Subtipo logo abaixo:

| Código | Texto |
| --- | --- |
| \`01\` | Transferência de Créditos p/ Cooperativa |
| \`02\` | Cancelamento de Créditos |
| \`03\` | Débitos Não Processados |
| \`04\` | Multas / Juros |
| \`05\` | Sucessão |
| \`06\` | Pagamento Antecipado |
| \`07\` | Perda de Estoque |
| \`08\` | Desenquadramento Simples Nacional |

Valores fora da tabela caem em fallback genérico \`(tpNFDebito=NN)\`.

## Backward compatibility

\`Finalidade=null\` (XMLs antigos) e \`Finalidade=1..4\` continuam renderizando \"DANFE\" — comportamento inalterado. \`tpNFDebito=null\` é o caso padrão.

## Validação

- [x] \`dotnet build DanfeSharp/DanfeSharp.csproj\`: 0 erros.
- [x] \`Finalidade=5\` continua renderizando \"NOTA DE CRÉDITO\" (lógica do PR #31 preservada).

## Test plan

- [ ] Após merge, bumpar submodule em \`dfetech-product-invoice-api\` e desfazer vendoring no PR #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)