### PR TITLE
chore(issue-templates): bootstrap padrao nfe

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,97 @@
+name: Bug
+type: Bug
+description: Defeito em comportamento existente. Use quando algo deveria funcionar de um jeito mas nao funciona.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/bug.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      description: "Quem reportou, por qual canal, link ou thread."
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "O que deveria acontecer? O que esta acontecendo? Em que ambiente foi observado?"
+    validations:
+      required: true
+  - type: textarea
+    id: passos-reproducao
+    attributes:
+      label: Passos para reproduzir
+      description: "Lista numerada minima para chegar no defeito."
+      placeholder: "1. ...\n2. ...\n3. (observa o erro)"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: "O comportamento esperado, em uma frase."
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "Como validar que esta corrigido. Inclua reproducao do passo 'comportamento esperado'."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Logs, traces, dashboards, threads, PRs relacionados. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: "Critical=critico em producao; High=funcional comprometido sem workaround; Medium=workaround possivel; Low=cosmetico."
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,76 @@
+name: Task / Chore
+type: Task
+description: Manutencao tecnica, limpeza, atualizacao de dependencia, refatoracao sem mudanca de comportamento, ajuste de configuracao. Use para trabalho operacional necessario que nao e feature, bug ou improvement.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/chore.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "Por que precisamos fazer isso? Que constraint, divida ou risco motivou?"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: "Resultado esperado em uma frase."
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "Como saber que terminou. Inclua impacto no sistema (ex: 'CI verde', 'lib X removida do package.json')."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "PRs, ADRs, threads, alertas. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Padrao oficial de issues NFe
+    url: https://github.com/nfe/.github
+    about: "Documentacao do padrao oficial de issues. Caso nenhum dos templates acima sirva, abra um chamado com o time AI Governance antes de criar issue em branco."

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,96 @@
+name: Docs
+type: Docs
+description: Producao ou atualizacao de documentacao (README, runbook, ADR, guia, wiki). Use quando o entregavel principal e texto, nao codigo.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/docs.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "Que duvida ou problema motivou a documentacao? Quem esta tentando resolver isso hoje?"
+    validations:
+      required: true
+  - type: textarea
+    id: audiencia
+    attributes:
+      label: Audiencia
+      description: "Quem vai ler. Ex: novo eng do time X, oncall, time de dados externo."
+    validations:
+      required: true
+  - type: dropdown
+    id: formato
+    attributes:
+      label: Formato final
+      options:
+        - "README"
+        - "Runbook"
+        - "ADR"
+        - "Wiki / portal"
+        - "Inline (codigo)"
+        - "Outro"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: "Apos ler, o leitor consegue fazer o que? (1 frase)"
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "O que conta como pronto. Inclua revisor."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Material existente sobre o tema. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,91 @@
+name: Feature
+type: Feature
+description: Nova funcionalidade. Use para implementar suporte novo, adicionar capacidade, habilitar fluxo inexistente.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/feature.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      description: "Quem solicitou, por qual canal, link ou thread."
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "Qual o problema atual? O que acontece se nao fizer? Quem e impactado?"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: "Resultado esperado em uma frase. Inclua usuario-alvo e metrica de sucesso."
+    validations:
+      required: true
+  - type: textarea
+    id: escopo-inclui
+    attributes:
+      label: "Escopo — Inclui"
+      description: "O que entra nesta issue."
+  - type: textarea
+    id: escopo-nao-inclui
+    attributes:
+      label: "Escopo — Nao inclui"
+      description: "O que fica para outra issue (evita scope creep)."
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "Lista objetivamente verificavel. Cada item deve ter metrica concreta."
+      placeholder: "- [ ] Endpoint /v1/foo retorna 200 com payload Y\n- [ ] Latencia p95 < 300ms"
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      description: "Issues, servicos, pessoas. 'Nenhuma' e resposta valida."
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Links, docs, threads, PRs, normas. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: "Vocabulario canonico da org (sem P0-P3)."
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      description: "Existe motivacao regulatoria? Se sim, qual a janela do prazo oficial?"
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,76 @@
+name: Improvement
+type: Improvement
+description: Otimizacao de algo existente que ja funciona. Use para reduzir latencia, simplificar fluxo, melhorar UX, refatorar com ganho mensuravel.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/improvement.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "Como o sistema funciona hoje? Qual o baseline atual (numero, threshold)?"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: "Qual a melhoria esperada? Quantifique (ex: p95 de 800ms para <300ms)."
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "Inclua a metrica concreta com valor alvo."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Dashboards, benchmarks, threads, PRs. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/incident.yml
+++ b/.github/ISSUE_TEMPLATE/incident.yml
@@ -1,0 +1,107 @@
+name: Incident
+type: Incident
+description: Evento de degradacao ou indisponibilidade que ja aconteceu (ou esta acontecendo). Use para postmortem, registro de causa raiz, follow-ups de remediacao.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/incident.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+
+        > Para incidentes ativos, abra primeiro o canal de war room e use esta issue para o
+        > registro pos-evento. Esta issue **nao** substitui o playbook de oncall.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      description: "Quem detectou, por qual canal/alerta, link da thread."
+      placeholder: "> Origem: alerta Grafana 'X' — thread #incident-2026-04-29 — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "O que aconteceu. Qual sistema/cliente foi afetado. Como foi detectado."
+    validations:
+      required: true
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: "Eventos com timestamp UTC ou America/Sao_Paulo. Inclua deteccao, mitigacao, resolucao."
+      placeholder: "- 14:02 BRT — primeiro alerta\n- 14:08 BRT — pageado oncall\n- ..."
+    validations:
+      required: true
+  - type: textarea
+    id: impacto
+    attributes:
+      label: Impacto quantificado
+      description: "Numero afetado (clientes, requests, R$). Duracao."
+    validations:
+      required: true
+  - type: textarea
+    id: causa-raiz
+    attributes:
+      label: Causa raiz
+      description: "5-whys ou equivalente. Se ainda em investigacao, deixar claro."
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao (follow-ups)
+      description: "Acoes para evitar recorrencia. Cada uma deve virar issue de chore/feature/improvement separada e ser linkada como sub-issue."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Dashboards, logs, threads de war room, runbooks. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: "Critical=indisponibilidade total; High=degradacao majoritaria sem workaround; Medium=workaround possivel; Low=cosmetico."
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,83 @@
+name: Spike
+type: Spike
+description: Investigacao com tempo limitado para reduzir incerteza tecnica antes de uma decisao. Use para PoC, analise de viabilidade, comparacao de abordagens, descoberta.
+title: "<verbo + objeto + qualificador>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Template placeholder publicado por `nfe:create-issue` (bootstrap). Sera substituido
+        > pelo canonico de `nfe/.github/.github/ISSUE_TEMPLATE/spike.yml` no proximo sync
+        > do provisioner em `nfe/.github#20`.
+  - type: textarea
+    id: origem
+    attributes:
+      label: Origem
+      placeholder: "> Origem: @fulano via Slack #canal-x — https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: "Qual a incerteza? Por que nao da pra decidir hoje? Que decisao depende disto?"
+    validations:
+      required: true
+  - type: textarea
+    id: pergunta-pesquisa
+    attributes:
+      label: Pergunta de pesquisa
+      description: "Uma frase clara que esta investigacao precisa responder."
+    validations:
+      required: true
+  - type: textarea
+    id: criterio-parar
+    attributes:
+      label: "Criterio de 'quando parar'"
+      description: "Time-box (ex: 2 dias) + sinal de saida (ex: 'rodou em staging com X transacoes')."
+    validations:
+      required: true
+  - type: textarea
+    id: criterios-aceitacao
+    attributes:
+      label: Criterios de aceitacao
+      description: "Output esperado: documento, ADR, demo, benchmark."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependencias
+      value: "Nenhuma"
+    validations:
+      required: true
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: "Material que ja existe sobre o tema. Minimo 1."
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance
+      options:
+        - "Nao"
+        - "Vigente"
+        - "<90d"
+        - ">90d"
+    validations:
+      required: true


### PR DESCRIPTION
## Resumo
- Bootstrap dos 8 templates oficiais (`feature`, `bug`, `improvement`, `spike`, `docs`, `chore`, `incident` + `config`) em `.github/ISSUE_TEMPLATE/`.
- Publicado automaticamente pela skill `nfe:create-issue` antes de abrir uma issue de spike (CNPJ alfanumerico, Reforma Tributaria).

## Por que
- O repo nao tinha `.github/ISSUE_TEMPLATE/`. Sem templates, issues criadas manualmente fogem do padrao DoR da org.
- Estes sao **placeholders** com as 7 secoes obrigatorias e dropdowns canonicos (`Critical/High/Medium/Low`). Espera-se que o sync diario do provisioner `nfe/.github#20` substitua pela versao canonica em ate 24h.

## Test plan
- [ ] Apos merge, verificar que `Nova Issue` no GitHub UI mostra os 7 tipos
- [ ] `blank_issues_enabled: false` impede criar issue sem template

Generated with Claude Code (https://claude.com/claude-code)