### PR TITLE
fix(paisagem): DANFE em paisagem saía quebrado (page size vs PrimitiveComposer)

### DIFF
--- a/DanfeSharp/DanfeEventoPagina.cs
+++ b/DanfeSharp/DanfeEventoPagina.cs
@@ -17,17 +17,21 @@ namespace DanfeSharp
             PdfPage = new Page(Danfe.PdfDocument);
             Danfe.PdfDocument.Pages.Add(PdfPage);
 
-            PrimitiveComposer = new PrimitiveComposer(PdfPage);
-            Gfx = new Gfx(PrimitiveComposer);
-
             if (Danfe.ViewModel.Orientacao == Orientacao.Retrato)
                 Retangulo = new RectangleF(0, 0, Constantes.A4Largura, Constantes.A4Altura);
             else
                 Retangulo = new RectangleF(0, 0, Constantes.A4Altura, Constantes.A4Largura);
 
+            // O tamanho da página precisa ser definido ANTES de instanciar o PrimitiveComposer
+            // (o pdfclown captura a altura da página para o flip do eixo Y na construção).
+            // Ver DanfePagina para o detalhe do bug em paisagem.
+            PdfPage.Size = new SizeF(Retangulo.Width.ToPoint(), Retangulo.Height.ToPoint());
+
+            PrimitiveComposer = new PrimitiveComposer(PdfPage);
+            Gfx = new Gfx(PrimitiveComposer);
+
             RetanguloDesenhavel = Retangulo.InflatedRetangle(Danfe.ViewModel.Margem);
             RetanguloCreditos = new RectangleF(RetanguloDesenhavel.X, RetanguloDesenhavel.Bottom + Danfe.EstiloPadrao.PaddingSuperior, RetanguloDesenhavel.Width, Retangulo.Height - RetanguloDesenhavel.Height - Danfe.EstiloPadrao.PaddingSuperior);
-            PdfPage.Size = new SizeF(Retangulo.Width.ToPoint(), Retangulo.Height.ToPoint());
         }
 
         #endregion

--- a/DanfeSharp/DanfePagina.cs
+++ b/DanfeSharp/DanfePagina.cs
@@ -25,18 +25,25 @@ namespace DanfeSharp
             Danfe = danfe ?? throw new ArgumentNullException(nameof(danfe));
             PdfPage = new Page(Danfe.PdfDocument);
             Danfe.PdfDocument.Pages.Add(PdfPage);
-         
+
+            if (Danfe.ViewModel.Orientacao == Orientacao.Retrato)
+                Retangulo = new RectangleF(0, 0, Constantes.A4Largura, Constantes.A4Altura);
+            else
+                Retangulo = new RectangleF(0, 0, Constantes.A4Altura, Constantes.A4Largura);
+
+            // IMPORTANTE: o tamanho da página precisa ser definido ANTES de instanciar o
+            // PrimitiveComposer. O pdfclown captura a altura da página (usada no flip do eixo Y
+            // para origem no topo-esquerdo) no momento da construção do composer. Se o composer
+            // for criado com o tamanho default (A4 retrato, 297mm) e a página só for redimensionada
+            // para paisagem (210mm) depois, todo o conteúdo fica deslocado ~87mm para cima e o
+            // cabeçalho sai da página. Ver DanfeEventoPagina para o mesmo cuidado.
+            PdfPage.Size = new SizeF(Retangulo.Width.ToPoint(), Retangulo.Height.ToPoint());
+
             PrimitiveComposer = new PrimitiveComposer(PdfPage);
             Gfx = new Gfx(PrimitiveComposer);
 
-            if (Danfe.ViewModel.Orientacao == Orientacao.Retrato)            
-                Retangulo = new RectangleF(0, 0, Constantes.A4Largura, Constantes.A4Altura);            
-            else            
-                Retangulo = new RectangleF(0, 0, Constantes.A4Altura, Constantes.A4Largura);
-            
             RetanguloDesenhavel = Retangulo.InflatedRetangle(Danfe.ViewModel.Margem);
             RetanguloCreditos = new RectangleF(RetanguloDesenhavel.X, RetanguloDesenhavel.Bottom + Danfe.EstiloPadrao.PaddingSuperior, RetanguloDesenhavel.Width, Retangulo.Height - RetanguloDesenhavel.Height - Danfe.EstiloPadrao.PaddingSuperior);
-            PdfPage.Size = new SizeF(Retangulo.Width.ToPoint(), Retangulo.Height.ToPoint());    
         }
 
         public void DesenharCreditos(string creditos)


### PR DESCRIPTION
## Problema

O DANFE gerado em orientação **Paisagem** (`tpImp=2`) saía quebrado: o bloco do cabeçalho (Identificação do Emitente, quadro DANFE, código de barras, Chave de Acesso, Destinatário e o topo do Cálculo do Imposto) ficava **fora da página** e o conteúdo visível aparecia deslocado ~87mm para cima, ocupando apenas a largura de retrato. Retrato sempre funcionou.

## Causa raiz

Em `DanfePagina` (e `DanfeEventoPagina`), a sequência era:

1. `PdfPage = new Page(doc)` → página criada com o tamanho **default (A4 retrato, 297mm de altura)**;
2. `new PrimitiveComposer(PdfPage)` → composer instanciado;
3. `PdfPage.Size = ... (paisagem, 210mm)` → página redimensionada **depois**.

O pdfclown captura a altura da página (usada no flip do eixo Y para origem no topo-esquerdo) **no momento da construção do `PrimitiveComposer`**. Como o composer nascia com 297mm e a página só virava paisagem (210mm) depois, o flip continuava usando 297mm numa página de 210mm → deslocamento de 297−210 = 87mm. Em retrato os valores coincidiam, por isso só a paisagem quebrava.

Isto também explica o comentário histórico em `DanfeViewModelCreator` que forçava `Retrato` ("o PDF modelo paisagem falhava").

## Correção

Definir `PdfPage.Size` **antes** de instanciar o `PrimitiveComposer`, nos dois pontos (`DanfePagina`, `DanfeEventoPagina`). Mudança mínima, apenas reordenação.

`DanfeNFC` e `DanfeSimplificadoTipo2` já criam a página com o tamanho no construtor (`new Page(doc, _size)`) — não eram afetados.

## Verificação

Renderizado a partir do domínio (via `DanfeService` do product-invoice), inspecionando os PDFs:
- **Retrato**: idêntico ao anterior — **sem regressão**.
- **Paisagem (1 item)**: agora renderiza **completo** — canhoto rotacionado à esquerda, cabeçalho, chave de acesso, destinatário, cálculo do imposto ocupando toda a largura, transportador, produtos e dados adicionais.
- **Paisagem (3 itens)**: tabela de produtos correta.

> Obs.: o projeto de testes legado `DanfeSharp.Test` (.NET Framework 4.6.1 / packages.config) não restaura no ambiente atual; a verificação foi feita via renderização real integrada ao product-invoice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
