### PR TITLE
feat(cnpj): CNPJ alfanumérico na main (Tipo2 + paisagem + CNPJ-alfa)

### DIFF
--- a/DanfeSharp.Test/DanfeSharp.Test.csproj
+++ b/DanfeSharp.Test/DanfeSharp.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="DanfeXmlTests.cs" />
     <Compile Include="Extentions.cs" />
     <Compile Include="FabricaFake.cs" />
+    <Compile Include="FormatadorTests.cs" />
     <Compile Include="LogoTests.cs" />
     <Compile Include="SimplePdfPageTester.cs" />
     <Compile Include="DanfeTest.cs" />

--- a/DanfeSharp.Test/DanfeTest.cs
+++ b/DanfeSharp.Test/DanfeTest.cs
@@ -60,7 +60,7 @@ namespace DanfeSharp.Test
             foreach (var pathXml in Directory.EnumerateFiles(pasta, "*.xml"))
             {
                 var model = DanfeEventoViewModelCreator.CriarDeArquivoXml(pathXml);
-                using (DanfeCCC danfe = new DanfeCCC(model))
+                using (DanfeCartaCorrecao danfe = new DanfeCartaCorrecao(model))
                 {
                     danfe.Gerar();
                     danfe.Salvar($"{caminhoOut}/{model.ChaveAcesso}.pdf");

--- a/DanfeSharp.Test/FormatadorTests.cs
+++ b/DanfeSharp.Test/FormatadorTests.cs
@@ -95,6 +95,30 @@ namespace DanfeSharp.Test
             Assert.AreEqual(input, Formatador.FormatarCpfCnpj(input));
         }
 
+        // Regressão (PR review #36): conteúdo inválido com comprimento "limpo" 11/14
+        // não deve perder a pontuação do input original — devolve trimmed, não clean.
+        [DataTestMethod]
+        [DataRow("12.abc.345/0001-88", DisplayName = "CNPJ alfanumérico minúsculo com máscara — rejeitado, preserva pontuação")]
+        [DataRow("12.ABC.345/0001-AB", DisplayName = "CNPJ com DV alfabético + máscara — rejeitado, preserva pontuação")]
+        [DataRow("123.456.789-0X", DisplayName = "CPF com letra + máscara — rejeitado, preserva pontuação")]
+        [DataRow("AB.CDE.FGH/IJKL-MN", DisplayName = "CNPJ todo letras + máscara — rejeitado pela regex (DV não-numérico)")]
+        public void FormatarCpfCnpj_InvalidoComMascara_PreservaPontuacaoDoInput(string input)
+        {
+            // Antes do fix: input "limpo" caía no dispatch por comprimento e perdia a pontuação.
+            // Após o fix: a regex valida o conteúdo limpo antes do dispatch; conteúdo inválido
+            // devolve `trimmed` (que mantém a pontuação original).
+            Assert.AreEqual(input, Formatador.FormatarCpfCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("12abc345000188", DisplayName = "CNPJ alfanumérico lowercase sem máscara — rejeitado, devolve cru")]
+        [DataRow("1234567890A", DisplayName = "CPF com letra sem máscara — rejeitado, devolve cru")]
+        public void FormatarCpfCnpj_InvalidoSemMascara_DevolveInputInalterado(string input)
+        {
+            // Conteúdo sem pontuação que falha a regex — `trimmed == clean`, devolve igual.
+            Assert.AreEqual(input, Formatador.FormatarCpfCnpj(input));
+        }
+
         [TestMethod]
         public void FormatarCpfCnpj_StringVazia_RetornaStringVazia()
         {

--- a/DanfeSharp.Test/FormatadorTests.cs
+++ b/DanfeSharp.Test/FormatadorTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DanfeSharp.Test
+{
+    /// <summary>
+    /// Cobertura do <see cref="Formatador"/> para CNPJ alfanumérico (Reforma
+    /// Tributária — LC 214/2025, vigência 2026-07-01) e regressão dos formatos
+    /// numéricos legados.
+    /// </summary>
+    [TestClass]
+    public class FormatadorTests
+    {
+        // CNPJ alfanumérico: regex agora aceita [0-9A-Z]{12}\d{2}. Máscara
+        // visual `XX.XXX.XXX/XXXX-XX` aplicada com letras nas posições corretas.
+
+        [DataTestMethod]
+        [DataRow("12345678000190", "12.345.678/0001-90", DisplayName = "CNPJ numérico legado")]
+        [DataRow("11222333000181", "11.222.333/0001-81", DisplayName = "CNPJ numérico válido")]
+        [DataRow("12ABC345000188", "12.ABC.345/0001-88", DisplayName = "CNPJ alfanumérico letras no meio")]
+        [DataRow("98XYZ123000158", "98.XYZ.123/0001-58", DisplayName = "CNPJ alfanumérico outro vetor")]
+        public void FormatarCnpj_FormatosValidos_AplicaMascara(string input, string expected)
+        {
+            Assert.AreEqual(expected, Formatador.FormatarCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("12.345.678/0001-90", "12.345.678/0001-90", DisplayName = "CNPJ já formatado (idempotência)")]
+        [DataRow("12.ABC.345/0001-88", "12.ABC.345/0001-88", DisplayName = "CNPJ alfanumérico já formatado")]
+        public void FormatarCnpj_JaFormatado_PreservaMascara(string input, string expected)
+        {
+            Assert.AreEqual(expected, Formatador.FormatarCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("12345678", DisplayName = "Muito curto")]
+        [DataRow("123456789012345", DisplayName = "Muito longo")]
+        [DataRow("12abc345000188", DisplayName = "Letras minúsculas — rejeitadas")]
+        [DataRow("12ABC345000ABCD", DisplayName = "DV alfanumérico — rejeitado")]
+        public void FormatarCnpj_ComprimentoOuFormatoInvalido_RetornaInputSemMascara(string input)
+        {
+            // Comportamento histórico: quando a regex não bate, o input é devolvido
+            // sem máscara, sem exception.
+            Assert.AreEqual(input, Formatador.FormatarCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("12345678901", "123.456.789-01")]
+        [DataRow("11144477735", "111.444.777-35")]
+        [DataRow("123.456.789-01", "123.456.789-01")]
+        public void FormatarCpf_FormatosValidos_AplicaMascara(string input, string expected)
+        {
+            Assert.AreEqual(expected, Formatador.FormatarCpf(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("1234567890A", DisplayName = "CPF com letra — rejeitado (CPF nunca aceita alfanumérico)")]
+        [DataRow("123", DisplayName = "Muito curto")]
+        [DataRow("123456789012", DisplayName = "Muito longo")]
+        public void FormatarCpf_FormatoInvalido_RetornaInputSemMascara(string input)
+        {
+            Assert.AreEqual(input, Formatador.FormatarCpf(input));
+        }
+
+        // FormatarCpfCnpj decide por comprimento da string limpa (sem máscara)
+        // antes da regex — eliminando ambiguidade quando um CNPJ alfanumérico
+        // pudesse acidentalmente bater na regex CPF (improvável mas defensivo).
+
+        [DataTestMethod]
+        [DataRow("12345678901", "123.456.789-01", DisplayName = "CPF numérico")]
+        [DataRow("11144477735", "111.444.777-35", DisplayName = "CPF numérico vetor 2")]
+        [DataRow("12345678000190", "12.345.678/0001-90", DisplayName = "CNPJ numérico legado")]
+        [DataRow("12ABC345000188", "12.ABC.345/0001-88", DisplayName = "CNPJ alfanumérico")]
+        [DataRow("98XYZ123000158", "98.XYZ.123/0001-58", DisplayName = "CNPJ alfanumérico vetor 2")]
+        public void FormatarCpfCnpj_FormatosValidos_AplicaMascaraCorrespondente(string input, string expected)
+        {
+            Assert.AreEqual(expected, Formatador.FormatarCpfCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("123.456.789-01", "123.456.789-01", DisplayName = "CPF com máscara — limpa e refaz")]
+        [DataRow("12.345.678/0001-90", "12.345.678/0001-90", DisplayName = "CNPJ com máscara — limpa e refaz")]
+        [DataRow("12.ABC.345/0001-88", "12.ABC.345/0001-88", DisplayName = "CNPJ alfanumérico com máscara — limpa e refaz")]
+        public void FormatarCpfCnpj_ComMascara_NormalizaEReaplica(string input, string expected)
+        {
+            Assert.AreEqual(expected, Formatador.FormatarCpfCnpj(input));
+        }
+
+        [DataTestMethod]
+        [DataRow("123", DisplayName = "3 chars — não é CPF nem CNPJ")]
+        [DataRow("123456789012", DisplayName = "12 chars — comprimento inválido")]
+        [DataRow("1234567890123", DisplayName = "13 chars — comprimento inválido")]
+        public void FormatarCpfCnpj_ComprimentoInvalido_RetornaInputTrimadoSemMascara(string input)
+        {
+            // Não joga exception (comportamento histórico). Apenas devolve trimado.
+            Assert.AreEqual(input, Formatador.FormatarCpfCnpj(input));
+        }
+
+        [TestMethod]
+        public void FormatarCpfCnpj_StringVazia_RetornaStringVazia()
+        {
+            Assert.AreEqual(string.Empty, Formatador.FormatarCpfCnpj(string.Empty));
+        }
+
+        [TestMethod]
+        public void FormatarCpfCnpj_Null_RetornaStringVazia()
+        {
+            Assert.AreEqual(string.Empty, Formatador.FormatarCpfCnpj(null));
+        }
+
+        [TestMethod]
+        public void FormatarCpfCnpj_StringComEspacos_TrimaAntesDeFormatar()
+        {
+            Assert.AreEqual("12.ABC.345/0001-88", Formatador.FormatarCpfCnpj("  12ABC345000188  "));
+        }
+    }
+}

--- a/DanfeSharp/Formatador.cs
+++ b/DanfeSharp/Formatador.cs
@@ -131,7 +131,12 @@ namespace DanfeSharp
         /// quando o CNPJ passa a aceitar letras nos 12 primeiros caracteres.
         /// </summary>
         /// <param name="cpfCnpj">Documento com ou sem máscara visual.</param>
-        /// <returns>Documento formatado, ou o input trimado se comprimento for inválido.</returns>
+        /// <returns>
+        ///   Documento formatado quando o conteúdo é válido (CPF de 11 dígitos OU
+        ///   CNPJ de 14 caracteres numéricos/alfanuméricos maiúsculos);
+        ///   o input trimado original caso contrário — preservando pontuação
+        ///   visível para entradas inválidas (comportamento histórico).
+        /// </returns>
         public static String FormatarCpfCnpj(String cpfCnpj)
         {
             if (String.IsNullOrWhiteSpace(cpfCnpj))
@@ -142,17 +147,25 @@ namespace DanfeSharp
             String trimmed = cpfCnpj.Trim();
             String clean = trimmed.Replace(".", String.Empty).Replace("-", String.Empty).Replace("/", String.Empty);
 
-            switch (clean.Length)
+            // Valida o conteúdo limpo contra a regex correspondente ANTES do dispatch.
+            // Sem essa validação, entradas como "12.abc.345/0001-88" (lowercase rejeitado
+            // pelo formato CNPJ alfanumérico) cairiam no dispatch por comprimento, o
+            // FormatarCnpj retornaria a string crua sem máscara, e a pontuação visível
+            // do input original seria perdida. Devolver `trimmed` para input inválido
+            // alinha com o contrato histórico: regex miss => input inalterado.
+            if (clean.Length == 11 && Regex.IsMatch(clean, CPF))
             {
-                case 11:
-                    return FormatarCpf(clean);
-                case 14:
-                    return FormatarCnpj(clean);
-                default:
-                    // Comprimento inválido — devolve sem aplicar máscara (comportamento
-                    // alinhado com o histórico: nunca jogou exception).
-                    return trimmed;
+                return FormatarCpf(clean);
             }
+
+            if (clean.Length == 14 && Regex.IsMatch(clean, CNPJ))
+            {
+                return FormatarCnpj(clean);
+            }
+
+            // Comprimento inválido OU conteúdo não bate na regex (ex.: lowercase em CNPJ
+            // alfanumérico, letras em CPF, DV alfabético) — devolve input trimado sem mexer.
+            return trimmed;
         }
 
         /// <summary>

--- a/DanfeSharp/Formatador.cs
+++ b/DanfeSharp/Formatador.cs
@@ -29,7 +29,10 @@ namespace DanfeSharp
         public const String FormatoNumeroNF = @"000\.000\.000";
 
         public const String CEP = @"^(\d{5})\-?(\d{3})$";
-        public const String CNPJ = @"^(\d{2})\.?(\d{3})\.?(\d{3})\/?(\d{4})\-?(\d{2})$";
+        // CNPJ aceita letras maiúsculas nos 12 primeiros caracteres a partir de 2026-07-01
+        // (Reforma Tributária, LC 214/2025 e IN RFB 2.229/2024). Os 2 últimos seguem como
+        // dígitos verificadores numéricos. CPF permanece estritamente numérico.
+        public const String CNPJ = @"^([0-9A-Z]{2})\.?([0-9A-Z]{3})\.?([0-9A-Z]{3})\/?([0-9A-Z]{4})\-?(\d{2})$";
         public const String CPF = @"^(\d{3})\.?(\d{3})\.?(\d{3})\-?(\d{2})$";
         public const String Telefone = @"^\(?(\d{2})\)?\s*(\d{4,5})\s*\-?\s*(\d{4})$";
         public const String Placa = @"^([A-Z]{3})\s*\-?\s*(\d{4})$";
@@ -122,33 +125,34 @@ namespace DanfeSharp
         }
 
         /// <summary>
-        /// Formata um número de documento
+        /// Formata um número de documento (CPF ou CNPJ).
+        /// Decide pelo comprimento da string limpa (sem máscara) antes de aplicar regex,
+        /// eliminando ambiguidade entre os formatos — relevante a partir de 2026-07-01,
+        /// quando o CNPJ passa a aceitar letras nos 12 primeiros caracteres.
         /// </summary>
-        /// <param name="cpfCnpj"></param>
-        /// <returns></returns>
+        /// <param name="cpfCnpj">Documento com ou sem máscara visual.</param>
+        /// <returns>Documento formatado, ou o input trimado se comprimento for inválido.</returns>
         public static String FormatarCpfCnpj(String cpfCnpj)
         {
-            String result;
-
-            if (!String.IsNullOrWhiteSpace(cpfCnpj))
+            if (String.IsNullOrWhiteSpace(cpfCnpj))
             {
-                result = cpfCnpj.Trim();
-
-                if (Regex.IsMatch(result, CPF))
-                {
-                    result = FormatarCpf(result);
-                }
-                else if (Regex.IsMatch(result, CNPJ))
-                {
-                    result = FormatarCnpj(result);
-                }
-            }
-            else
-            {
-                result = String.Empty;
+                return String.Empty;
             }
 
-            return result;
+            String trimmed = cpfCnpj.Trim();
+            String clean = trimmed.Replace(".", String.Empty).Replace("-", String.Empty).Replace("/", String.Empty);
+
+            switch (clean.Length)
+            {
+                case 11:
+                    return FormatarCpf(clean);
+                case 14:
+                    return FormatarCnpj(clean);
+                default:
+                    // Comprimento inválido — devolve sem aplicar máscara (comportamento
+                    // alinhado com o histórico: nunca jogou exception).
+                    return trimmed;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## O que

Traz o **formatter de CNPJ alfanumérico** (Reforma Tributária, vigência 2026-07-01) para a `main` do DanfeSharp, via merge do branch `feat/cnpj-alphanumeric-formatter`. A `main` já tinha **DANFE Simplificado Tipo 2** (#48) e o **fix de paisagem** (#49); com este merge a `main` passa a ter os **três**: Tipo 2 + paisagem + CNPJ-alfa.

## Conteúdo (merge limpo, sem conflitos)
- `Formatador.cs`: `FormatarCnpj`/`FormatarCpfCnpj` aceitam CNPJ com letras nos 12 primeiros caracteres (regex `^([0-9A-Z]{2})\.?([0-9A-Z]{3})\.?([0-9A-Z]{3})\/?([0-9A-Z]{4})\-?(\d{2})$`), preservando pontuação do input quando inválido.
- `FormatadorTests.cs` (novo): cobertura do formatter.
- `fix(test)`: `DanfeCCC` → `DanfeCartaCorrecao` (destrava o build do `DanfeSharp.Test`).

## Por que na main
Necessário para a integração **#155 (CNPJ alfanumérico)** que vai ao staging via nfe/dfetech-product-invoice-api#317. Consolidar na `main` evita divergência do submódulo (a feature estava só num branch).

## Validação
Renderização do DANFE via product-invoice (`DanfeService`) com CNPJ alfanumérico e numérico — amostras geradas na sequência da integração.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
